### PR TITLE
fix build for later versions of pip (e.g. on Travis CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,7 @@ install:
   - "deactivate"
   - "virtualenv --clear --python /usr/bin/python $MY_VIRTUAL_ENV"
   - "source $MY_VIRTUAL_ENV/bin/activate"
-  - "pip install pytest nose mock"
-  - "python ez_setup.py"
-  - "pip install -r requirements.txt --find-links http://cheshire3.liv.ac.uk/download/latest/reqs/ --allow-unverified PyZ3950 --allow-unverified ZSI"
-  - "python setup.py install"
+  - "bash make.sh"
 # Run tests for Cheshire3 and archiveshub
 script:
-  - python -m cheshire3.test.testAll
-  - python setup.py test
+  - "bash test.sh"

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+pip install pytest nose mock
+python ez_setup.py
+pip install -r requirements.txt --find-links http://cheshire3.liv.ac.uk/download/latest/reqs/ --trusted-host cheshire3.liv.ac.uk --allow-unverified PyZ3950 --allow-unverified ZSI
+python setup.py install

--- a/make.sh
+++ b/make.sh
@@ -3,3 +3,4 @@ pip install pytest nose mock
 python ez_setup.py
 pip install -r requirements.txt --find-links http://cheshire3.liv.ac.uk/download/latest/reqs/ --trusted-host cheshire3.liv.ac.uk --allow-unverified PyZ3950 --allow-unverified ZSI
 python setup.py install
+exit $?

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from ez_setup import use_setuptools
 use_setuptools()
 
 from setuptools import setup
-from pip.req import parse_requirements
+
 
 from archiveshub.setuptools.commands import (
     develop,
@@ -33,11 +33,16 @@ setuppath = inspect.getfile(inspect.currentframe())
 setupdir = dirname(setuppath)
 
 # Requirements
-_install_requires = [str(req.req)
-                     for req
-                     in parse_requirements('requirements.txt')
-                     if req.req
-                     ]
+_install_requires = [
+    'cheshire3[web,sql]>=1.1.8',
+    'CherryPy<3.4,>=3.0.0',
+    'hgapi',
+    'lockfile',
+    'Mako>=0.7.3',
+    'Pygments==1.6',
+    'uwsgi',
+    'webob>=1.2'
+]
 
 
 setup(

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+createdb cheshire3
 python -m cheshire3.test.testAll && python setup.py test
 exit $?

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-python -m cheshire3.test.testAll
-python setup.py test
+python -m cheshire3.test.testAll && python setup.py test
+exit $?

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+python -m cheshire3.test.testAll
+python setup.py test


### PR DESCRIPTION
Fix setup.py to work with latest versions of pip, and so build successfully on Travis CI so that hopefully "build status" badge returns to "success" 
